### PR TITLE
Cleanup and update to PHP5 class conventions

### DIFF
--- a/pve2_api.class.php
+++ b/pve2_api.class.php
@@ -2,84 +2,54 @@
 
 /*
 
-Copyright (c) 2012 Nathan Sullivan
+Proxmox VE APIv2 (PVE2) Client - PHP Class
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2012-2014 Nathan Sullivan
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions: 
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 
 */
 
+class PVE2_Exception extends RuntimeException {}
+
 class PVE2_API {
-	private $constructor_success;
+	protected $hostname;
+	protected $username;
+	protected $realm;
+	protected $password;
 
-	protected $pve_hostname;
-	protected $pve_username;
-	protected $pve_realm;
-	protected $pve_password;
+	protected $login_ticket = null;
+	protected $login_ticket_timestamp = null;
+	protected $cluster_node_list = null;
 
-	private $print_debug;
-
-	protected $pve_login_ticket;
-	protected $pve_login_ticket_timestamp;
-	protected $pve_cluster_node_list;
-
-	public function __construct ($pve_hostname, $pve_username, $pve_realm, $pve_password) {
-		if (empty($pve_hostname) || empty($pve_username) || empty($pve_realm) || empty($pve_password)) {
-			# TODO - better error handling?
-			print("Error - Hostname/Username/Realm/Password required for PVE_API object constructor.\n");
-			$this->constructor_success = false;
-			return false;
+	public function __construct ($hostname, $username, $realm, $password) {
+		if (empty($hostname) || empty($username) || empty($realm) || empty($password)) {
+			throw new PVE2_Exception("Hostname/Username/Realm/Password required for PVE2_API object constructor.", 1);
 		}
-		# Check hostname resolves.
-		if (gethostbyname($pve_hostname) == $pve_hostname && !filter_var($pve_hostname, FILTER_VALIDATE_IP)) {
-			# TODO - better error handling?
-			print("Cannot resolve ".$pve_hostname.", exiting.\n");
-			$this->constructor_success = false;
-			return false;
+		// Check hostname resolves.
+		if (gethostbyname($hostname) == $hostname && !filter_var($hostname, FILTER_VALIDATE_IP)) {
+			throw new PVE2_Exception("Cannot resolve {$hostname}.", 2);
 		}
 
-		$this->pve_hostname = $pve_hostname;
-		$this->pve_username = $pve_username;
-		$this->pve_realm = $pve_realm;
-		$this->pve_password = $pve_password;
-
-		$this->print_debug = false;
-
-		# Default this to null, so we can check later on if were logged in or not.
-		$this->pve_login_ticket = null;
-		$this->pve_login_ticket_timestamp = null;
-		$this->pve_cluster_node_list = null;
-		$this->constructor_success = true;
-	}
-
-	public function constructor_success () {
-		return $this->constructor_success;
-	}
-
-	private function convert_postfields_array_to_string ($postfields_array) {
-		$postfields_key_values = array();
-		foreach ($postfields_array as $field_key => $field_value) {
-			$postfields_key_values[] = urlencode($field_key)."=".urlencode($field_value);
-		}
-		$postfields_string = implode("&", $postfields_key_values);
-		return $postfields_string;
-	}
-
-	/*
-	 * bool set_debug (bool on_off)
-	 * Sets if we should print() debug information throughout the process,
-	 * to assist in troubleshooting...
-	 */
-	public function set_debug ($on_off) {
-		if (is_bool($on_off)) {
-			$this->print_debug = $on_off;
-			return true;
-		} else {
-			return false;
-		}
+		$this->hostname = $hostname;
+		$this->username = $username;
+		$this->realm = $realm;
+		$this->password = $password;
 	}
 
 	/*
@@ -87,28 +57,25 @@ class PVE2_API {
 	 * Performs login to PVE Server using JSON API, and obtains Access Ticket.
 	 */
 	public function login () {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# Prepare login variables.
+		// Prepare login variables.
 		$login_postfields = array();
-		$login_postfields['username'] = $this->pve_username;
-		$login_postfields['password'] = $this->pve_password;
-		$login_postfields['realm'] = $this->pve_realm;
+		$login_postfields['username'] = $this->username;
+		$login_postfields['password'] = $this->password;
+		$login_postfields['realm'] = $this->realm;
 
-		$login_postfields_string = $this->convert_postfields_array_to_string($login_postfields);
+		$login_postfields_string = http_build_query($login_postfields);
 		unset($login_postfields);
 
-		# Perform login request.
+		// Perform login request.
 		$prox_ch = curl_init();
-		curl_setopt($prox_ch, CURLOPT_URL, "https://".$this->pve_hostname.":8006/api2/json/access/ticket");
+		curl_setopt($prox_ch, CURLOPT_URL, "https://{$this->hostname}:8006/api2/json/access/ticket");
 		curl_setopt($prox_ch, CURLOPT_POST, true);
 		curl_setopt($prox_ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($prox_ch, CURLOPT_POSTFIELDS, $login_postfields_string);
 		curl_setopt($prox_ch, CURLOPT_SSL_VERIFYPEER, false);
 
 		$login_ticket = curl_exec($prox_ch);
+		$login_request_info = curl_getinfo($prox_ch);
 
 		curl_close($prox_ch);
 		unset($prox_ch);
@@ -116,35 +83,40 @@ class PVE2_API {
 
 		$login_ticket_data = json_decode($login_ticket, true);
 		if ($login_ticket_data == null) {
-			# Login failed.
-			# Just to be safe, set this to null again.
-			$this->pve_login_ticket_timestamp = null;
+			// Login failed.
+			// Just to be safe, set this to null again.
+			$this->login_ticket_timestamp = null;
+			if ($login_request_info['ssl_verify_result'] == 1) {
+				throw new PVE2_Exception("Invalid SSL cert on {$this->hostname} - check that the hostname is correct, and that it appears in the server certificate's SAN list.", 4);
+			}
 			return false;
 		} else {
-			# Login success.
-			$this->pve_login_ticket = $login_ticket_data['data'];
-			# We store a UNIX timestamp of when the ticket was generated here, so we can identify when we need
-			# a new one expiration wise later on...
-			$this->pve_login_ticket_timestamp = time();
+			// Login success.
+			$this->login_ticket = $login_ticket_data['data'];
+			// We store a UNIX timestamp of when the ticket was generated here,
+			// so we can identify when we need a new one expiration-wise later
+			// on...
+			$this->login_ticket_timestamp = time();
+			$this->reload_node_list();
 			return true;
 		}
 	}
 
 	/*
-	 * bool pve_check_login_ticket ()
+	 * bool check_login_ticket ()
 	 * Checks if the login ticket is valid still, returns false if not.
 	 * Method of checking is purely by age of ticket right now...
 	 */
-	protected function pve_check_login_ticket () {
-		if ($this->pve_login_ticket == null) {
-			# Just to be safe, set this to null again.
-			$this->pve_login_ticket_timestamp = null;
+	protected function check_login_ticket () {
+		if ($this->login_ticket == null) {
+			// Just to be safe, set this to null again.
+			$this->login_ticket_timestamp = null;
 			return false;
 		}
-		if ($this->pve_login_ticket_timestamp >= (time() + 7200)) {
-			# Reset login ticket object values.
-			$this->pve_login_ticket = null;
-			$this->pve_login_ticket_timestamp = null;
+		if ($this->login_ticket_timestamp >= (time() + 7200)) {
+			// Reset login ticket object values.
+			$this->login_ticket = null;
+			$this->login_ticket_timestamp = null;
 			return false;
 		} else {
 			return true;
@@ -152,81 +124,68 @@ class PVE2_API {
 	}
 
 	/*
-	 * object pve_action (string action_path, string http_method[, array put_post_parameters])
+	 * object action (string action_path, string http_method[, array put_post_parameters])
 	 * This method is responsible for the general cURL requests to the JSON API,
 	 * and sits behind the abstraction layer methods get/put/post/delete etc.
 	 */
-	private function pve_action ($action_path, $http_method, $put_post_parameters = null) {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# Check if we have a prefixed / on the path, if not add one.
+	private function action ($action_path, $http_method, $put_post_parameters = null) {
+		// Check if we have a prefixed / on the path, if not add one.
 		if (substr($action_path, 0, 1) != "/") {
 			$action_path = "/".$action_path;
 		}
 
-		if (!$this->pve_check_login_ticket()) {
-			if ($this->print_debug === true) {
-				print("Error - Not logged into Proxmox Host. No Login Access Ticket found or Ticket Expired.\n");
-			}
-			return false;
+		if (!$this->check_login_ticket()) {
+			throw new PVE2_Exception("Not logged into Proxmox host. No Login access ticket found or ticket expired.", 3);
 		}
 
-		# Prepare cURL resource.
+		// Prepare cURL resource.
 		$prox_ch = curl_init();
-		if ($this->print_debug === true) {
-			print("\nURL - https://".$this->pve_hostname.":8006/api2/json".$action_path."\n");
-		}
-		curl_setopt($prox_ch, CURLOPT_URL, "https://".$this->pve_hostname.":8006/api2/json".$action_path);
+		curl_setopt($prox_ch, CURLOPT_URL, "https://{$this->hostname}:8006/api2/json{$action_path}");
 
 		$put_post_http_headers = array();
-		$put_post_http_headers[] = "CSRFPreventionToken: ".$this->pve_login_ticket['CSRFPreventionToken'];
-		# Lets decide what type of action we are taking...
+		$put_post_http_headers[] = "CSRFPreventionToken: {$this->login_ticket['CSRFPreventionToken']}";
+		// Lets decide what type of action we are taking...
 		switch ($http_method) {
 			case "GET":
-				# Nothing extra to do.
+				// Nothing extra to do.
 				break;
 			case "PUT":
 				curl_setopt($prox_ch, CURLOPT_CUSTOMREQUEST, "PUT");
 
-				# Set "POST" data.
-				$action_postfields_string = $this->convert_postfields_array_to_string($put_post_parameters);
+				// Set "POST" data.
+				$action_postfields_string = http_build_query($put_post_parameters);
 				curl_setopt($prox_ch, CURLOPT_POSTFIELDS, $action_postfields_string);
 				unset($action_postfields_string);
 
-				# Add required HTTP headers.
+				// Add required HTTP headers.
 				curl_setopt($prox_ch, CURLOPT_HTTPHEADER, $put_post_http_headers);
 				break;
 			case "POST":
 				curl_setopt($prox_ch, CURLOPT_POST, true);
 
-				# Set POST data.
-				$action_postfields_string = $this->convert_postfields_array_to_string($put_post_parameters);
+				// Set POST data.
+				$action_postfields_string = http_build_query($put_post_parameters);
 				curl_setopt($prox_ch, CURLOPT_POSTFIELDS, $action_postfields_string);
 				unset($action_postfields_string);
 
-				# Add required HTTP headers.
+				// Add required HTTP headers.
 				curl_setopt($prox_ch, CURLOPT_HTTPHEADER, $put_post_http_headers);
 				break;
 			case "DELETE":
 				curl_setopt($prox_ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+				// No "POST" data required, the delete destination is specified in the URL.
 
-				# No "POST" data required, the delete destination is specified in the URL.
-
-				# Add required HTTP headers.
+				// Add required HTTP headers.
 				curl_setopt($prox_ch, CURLOPT_HTTPHEADER, $put_post_http_headers);
 				break;
 			default:
-				if ($this->print_debug === true) {
-					print("Error - Invalid HTTP Method specified.\n");	
-				}
+				throw new PVE2_Exception("Error - Invalid HTTP Method specified.", 5);	
 				return false;
 		}
 
 		curl_setopt($prox_ch, CURLOPT_HEADER, true);
 		curl_setopt($prox_ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($prox_ch, CURLOPT_COOKIE, "PVEAuthCookie=".$this->pve_login_ticket['ticket']);
+		curl_setopt($prox_ch, CURLOPT_COOKIE, "PVEAuthCookie=".$this->login_ticket['ticket']);
 		curl_setopt($prox_ch, CURLOPT_SSL_VERIFYPEER, false);
 
 		$action_response = curl_exec($prox_ch);
@@ -237,34 +196,20 @@ class PVE2_API {
 		$split_action_response = explode("\r\n\r\n", $action_response, 2);
 		$header_response = $split_action_response[0];
 		$body_response = $split_action_response[1];
-
-		if ($this->print_debug === true) {
-			print("----------------------------------------------\n");
-
-			print("\nFULL RESPONSE:\n\n");
-			print($action_response);
-			print("\n\nEND FULL RESPONSE.\n");
-
-			print("\nHeaders:\n\n");
-			print($header_response);
-			print("\n\nEnd Headers.\n");
-
-			print("\nData:\n\n");
-			print($body_response);
-			print("\n\nEnd Headers.\n");
-		}
-
 		$action_response_array = json_decode($body_response, true);
-		if ($this->print_debug === true) {
-			print("\nRESPONSE ARRAY:\n\n");
-			print_r($action_response_array);
-			print("\nEND RESPONSE ARRAY.\n");
-			print("----------------------------------------------\n");
-		}
+
+		$action_response_export = var_export($action_response_array, true);
+		error_log("----------------------------------------------\n" .
+			"FULL RESPONSE:\n\n{$action_response}\n\nEND FULL RESPONSE\n\n" .
+			"Headers:\n\n{$header_response}\n\nEnd Headers\n\n" .
+			"Data:\n\n{$body_response}\n\nEnd Data\n\n" .
+			"RESPONSE ARRAY:\n\n{$action_response_export}\n\nEND RESPONSE ARRAY\n" .
+			"----------------------------------------------");
 
 		unset($action_response);
+		unset($action_response_export);
 
-		# Parse response, confirm HTTP response code etc.
+		// Parse response, confirm HTTP response code etc.
 		$split_headers = explode("\r\n", $header_response);
 		if (substr($split_headers[0], 0, 9) == "HTTP/1.1 ") {
 			$split_http_response_line = explode(" ", $split_headers[0]);
@@ -275,30 +220,21 @@ class PVE2_API {
 					return $action_response_array['data'];
 				}
 			} else {
-				if ($this->print_debug === true) {
-					print("This API Request Failed.\n");
-					print("HTTP Response - ".$split_http_response_line[1]."\n");
-					print("HTTP Error - ".$split_headers[0]."\n");
-				}
+				error_log("This API Request Failed.\n" . 
+					"HTTP Response - {$split_http_response_line[1]}\n" . 
+					"HTTP Error - {$split_headers[0]}");
 				return false;
 			}
 		} else {
-			if ($this->print_debug === true) {
-				print("Error - Invalid HTTP Response.\n");
-				print_r($split_headers);
-				print("\n");
-			}
+			error_log("Error - Invalid HTTP Response.\n" . var_export($split_headers, true));
 			return false;
 		}
 
 		if (!empty($action_response_array['data'])) {
 			return $action_response_array['data'];
 		} else {
-			if ($this->print_debug === true) {
-				print("Error - \$action_response_array['data'] is empty. Returning false.\n");
-				var_dump($action_response_array['data']);
-				print("\n");
-			}
+			error_log("\$action_response_array['data'] is empty. Returning false.\n" . 
+				var_export($action_response_array['data'], true));
 			return false;
 		}
 	}
@@ -310,22 +246,16 @@ class PVE2_API {
 	 * ie. $this->get("nodes/XXX/status"); where XXX is one of the values from this return array.
 	 */
 	public function reload_node_list () {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		$node_list = $this->pve_action("/nodes", "GET");
+		$node_list = $this->get("/nodes");
 		if (count($node_list) > 0) {
 			$nodes_array = array();
 			foreach ($node_list as $node) {
 				$nodes_array[] = $node['node'];
 			}
-			$this->pve_cluster_node_list = $nodes_array;
+			$this->cluster_node_list = $nodes_array;
 			return true;
 		} else {
-			if ($this->print_debug === true) {
-				print("Error - Empty list of nodes returned in this cluster.\n");
-			}
+			error_log(" Empty list of nodes returned in this cluster.");
 			return false;
 		}
 	}
@@ -335,16 +265,15 @@ class PVE2_API {
 	 *
 	 */
 	public function get_node_list () {
-		# We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
-		if ($this->pve_cluster_node_list == null) {
+		// We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
+		if ($this->cluster_node_list == null) {
 			if ($this->reload_node_list() === false) {
 				return false;
 			}
 		}
 
-		return $this->pve_cluster_node_list;
+		return $this->cluster_node_list;
 	}
-
 	
 	/*
 	 * bool|int get_next_vmid ()
@@ -352,10 +281,7 @@ class PVE2_API {
 	 * returns a VMID, or false if not found.
 	 */
 	public function get_next_vmid () {
-		if (!$this->constructor_success) {
-			return false;
-		}
-		$vmid = $this->pve_action("/cluster/nextid","GET");
+		$vmid = $this->get("/cluster/nextid");
 		if ($vmid == null) {
 			return false;
 		} else {
@@ -368,10 +294,7 @@ class PVE2_API {
 	 * Return the version and minor revision of Proxmox Server
 	 */
 	public function get_version () {
-		if (!$this->constructor_success) {
-			return false;
-		}
-		$version = $this->pve_action("/version","GET");
+		$version = $this->get("/version");
 		if ($version == null) {
 			return false;
 		} else {
@@ -383,75 +306,31 @@ class PVE2_API {
 	 * object/array? get (string action_path)
 	 */
 	public function get ($action_path) {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
-		if ($this->pve_cluster_node_list == null) {
-			if ($this->reload_node_list() === false) {
-				return false;
-			}
-		}
-
-		return $this->pve_action($action_path, "GET");
+		return $this->action($action_path, "GET");
 	}
 
 	/*
 	 * bool put (string action_path, array parameters)
 	 */
 	public function put ($action_path, $parameters) {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
-		if ($this->pve_cluster_node_list == null) {
-			if ($this->reload_node_list() === false) {
-				return false;
-			}
-		}
-
-		return $this->pve_action($action_path, "PUT", $parameters);
+		return $this->action($action_path, "PUT", $parameters);
 	}
 
 	/*
 	 * bool post (string action_path, array parameters)
 	 */
 	public function post ($action_path, $parameters) {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
-		if ($this->pve_cluster_node_list == null) {
-			if ($this->reload_node_list() === false) {
-				return false;
-			}
-		}
-
-		return $this->pve_action($action_path, "POST", $parameters);
+		return $this->action($action_path, "POST", $parameters);
 	}
 
 	/*
 	 * bool delete (string action_path)
 	 */
 	public function delete ($action_path) {
-		if (!$this->constructor_success) {
-			return false;
-		}
-
-		# We run this if we haven't queried for cluster nodes as yet, and cache it in the object.
-		if ($this->pve_cluster_node_list == null) {
-			if ($this->reload_node_list() === false) {
-				return false;
-			}
-		}
-
-		return $this->pve_action($action_path, "DELETE");
+		return $this->action($action_path, "DELETE");
 	}
 
-	# Logout not required, PVEAuthCookie tokens have a 2 hour lifetime.
+	// Logout not required, PVEAuthCookie tokens have a 2 hour lifetime.
 }
 
 ?>


### PR DESCRIPTION
- Should throw exceptions on errors that prevent proper `__cosntruct()` execution.
- Should throw exceptions on errors that prevent proper execution of other logic, unless actual error handling is implemented internally to such logic.

Also minimized operation overhead by moving initial node list loading to end of successful login, instead of on every action possible post-login.  (There were checks to determine if upstream requests were required to fulfill this need, but that check itself presents an amount of overhead which can be undesirable in a high performance, high request load situation.)

Additionally, removed superfluous `pve_` from property and method names.  The fact that they are part of the `PVE2_API` class tells us that much of their nature.  The fact that all were in protected/private scope makes the extra characters even more unnecessary.

----

NOTE: `diff` isn't very smart about detecting when newlines are added to existing text, so the first several changes (until about line 83 in the old/53 in the new) are less drastic than they appear.  (`git` uses `diff` rather than replicate its functionality because Linus believes in not reinventing wheels he doesn't have to; git is obviously a wheel he had to :grin: )